### PR TITLE
Feat/add confirm delete cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ deletor -cli -d ~/Downloads -e mp4,zip  --min-size 10mb -subdirs --exclude data,
 
 `-progress` - display a progress bar during file scanning
 
+`-confirm-delete` - if present will skip the final confirmation check 
+
 
 ## ✨ The Power of Dual Modes: TUI and CLI
 

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	ShowProgress   bool
 	IsCLIMode      bool
 	HaveProgress   bool
+	ConfirmDelete  bool
 }
 
 func LoadConfig() *Config {

--- a/internal/cli/config/flags.go
+++ b/internal/cli/config/flags.go
@@ -19,6 +19,7 @@ func GetFlags() *Config {
 	includeSubdirsScan := flag.Bool("subdirs", false, "Include subdirectories in scan")
 	isCLIMode := flag.Bool("cli", false, "CLI mode (default is TUI)")
 	progress := flag.Bool("progress", false, "Display a progress bar during file scanning")
+	confirmDelete := flag.Bool("confirm-delete", false, "Confirm that files are to be deleted?")
 
 	flag.Parse()
 
@@ -50,5 +51,6 @@ func GetFlags() *Config {
 	config.HaveProgress = *progress
 	config.IncludeSubdirs = *includeSubdirsScan
 	config.Directory = *dir
+	config.ConfirmDelete = *confirmDelete
 	return config
 }

--- a/main.go
+++ b/main.go
@@ -102,11 +102,11 @@ func main() {
 		if len(toDeleteMap) != 0 {
 			printer.PrintFilesTable(toDeleteMap)
 
-			fmt.Println(utils.FormatSize(totalClearSize), "will be cleared.")
-
 			actionIsDelete := true
 
+			fmt.Println() // This is required for formatting
 			if !config.ConfirmDelete {
+				fmt.Println(utils.FormatSize(totalClearSize), "will be cleared.")
 				actionIsDelete = printer.AskForConfirmation("Delete these files?")
 			}
 

--- a/main.go
+++ b/main.go
@@ -102,10 +102,13 @@ func main() {
 		if len(toDeleteMap) != 0 {
 			printer.PrintFilesTable(toDeleteMap)
 
-			fmt.Println()
 			fmt.Println(utils.FormatSize(totalClearSize), "will be cleared.")
 
-			actionIsDelete := printer.AskForConfirmation("Delete these files?")
+			actionIsDelete := true
+
+			if !config.ConfirmDelete {
+				actionIsDelete = printer.AskForConfirmation("Delete these files?")
+			}
 
 			if actionIsDelete {
 				printer.PrintSuccess("Deleted: %s", utils.FormatSize(totalClearSize))
@@ -116,7 +119,6 @@ func main() {
 
 				utils.LogDeletionToFile(toDeleteMap)
 			}
-
 		} else {
 			printer.PrintWarning("File not found")
 		}


### PR DESCRIPTION
Add optional confirm-delete flag for CLI mode

This PR implements issue #84 by adding an optional confirmation flag for file deletions in CLI mode.

Changes:
- Added a new `-confirm-delete` flag that will skip prompts for confirmation before deleting files if present in the prompt
- Default behaviour remains unchanged (no confirmation prompt)
- Added appropriate documentation for the new flag
- Edited the way that the printer.AskForConfirmation function is called

This provides users with the option to skip the safety check when needed, while maintaining the existing workflow for those who prefer the current behaviour.