### PR TITLE
Edited file filtering logic to include zero byte files when using the CLI

### DIFF
--- a/internal/filemanager/filters.go
+++ b/internal/filemanager/filters.go
@@ -24,5 +24,5 @@ func (f *FileFilter) MatchesFilters(info os.FileInfo, path string) bool {
 		}
 	}
 
-	return info.Size() > f.MinSize && f.Extensions[filepath.Ext(info.Name())]
+	return info.Size() >= f.MinSize && f.Extensions[filepath.Ext(info.Name())]
 }


### PR DESCRIPTION
0Byte file sizes are not being found in CLI mode

This PR implements fix for 0Byte file sizes are not being found in CLI mode #88  by editing the lowest size possible.

Changes:

Edited the existing behaviour to allow zero byte files to match the filtering


Default behaviour remains unchanged
No documentation changes required