### PR TITLE
adding linux cache deletion

### DIFF
--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -82,7 +83,15 @@ func (m *Manager) ClearCache() {
 				err := os.Remove(path)
 				if err != nil {
 					if runtime.GOOS == "windows" {
-						deleteFileWithWindowsAPI(path)
+						err := deleteFileWithWindowsAPI(path)
+						fmt.Println(err)
+					}
+
+					if runtime.GOOS == "Unix" || runtime.GOOS == "Linux" {
+						err := deleteFileWithLinuxAPI(path)
+						if err != nil {
+							return err
+						}
 					}
 				}
 				return nil
@@ -91,4 +100,8 @@ func (m *Manager) ClearCache() {
 			return nil
 		})
 	}
+}
+
+func deleteFileWithWindowsAPI(path string) interface{} {
+	return deleteFileWithWindowsAPI(path)
 }

--- a/internal/cache/unix.go
+++ b/internal/cache/unix.go
@@ -1,9 +1,28 @@
-//go:build !windows
-// +build !windows
+//go:build linux || darwin
+// +build linux darwin
 
 package cache
 
-func deleteFileWithWindowsAPI(path string) error {
+import (
+	"golang.org/x/sys/unix"
+)
+
+func deleteFileWithLinuxAPI(path string) error {
 	// This is a stub for non-Windows platforms
-	return nil
+
+	var stat unix.Stat_t
+	err := unix.Stat(path, &stat)
+	if err != nil {
+		return err
+	}
+
+	if stat.Mode&0744 != 0 {
+		err := unix.Chmod(path, 0744)
+		if err != nil {
+			return err
+		}
+	}
+
+	return unix.Rmdir(path)
+
 }

--- a/internal/cache/windows.go
+++ b/internal/cache/windows.go
@@ -22,7 +22,10 @@ func deleteFileWithWindowsAPI(path string) error {
 
 	// Remove read-only attribute if present
 	if attrs&windows.FILE_ATTRIBUTE_READONLY != 0 {
-		windows.SetFileAttributes(pathPtr, attrs&^windows.FILE_ATTRIBUTE_READONLY)
+		err := windows.SetFileAttributes(pathPtr, attrs&^windows.FILE_ATTRIBUTE_READONLY)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Try to delete with Windows API

--- a/internal/tui/views/cache.go
+++ b/internal/tui/views/cache.go
@@ -220,8 +220,8 @@ func (m *CacheModel) handleSpace() (tea.Model, tea.Cmd) {
 
 		return m, nil
 	} else if m.FocusedElement == "deleteButton" {
-		if runtime.GOOS != "windows" {
-			m.status = "Currently only Windows is supported for cache clearing\n"
+		if runtime.GOOS == "darwin" {
+			m.status = "Currently only Windows and linux is supported for cache clearing\n"
 		} else {
 			m.cacheManager.ClearCache()
 			m.scanResults = []cache.ScanResult{}


### PR DESCRIPTION
fixes: #140 

Added linux cache deletion functionality. Uses the go unix package to do the operation 

Before cache deletion:

<img width="1470" alt="Screenshot 2025-05-31 at 12 04 24 AM" src="https://github.com/user-attachments/assets/35494762-3c4b-4923-b4c8-241ce5919be6" />

Deletion process

<img width="1470" alt="Screenshot 2025-05-31 at 12 04 52 AM" src="https://github.com/user-attachments/assets/5b7787e5-8e5d-41c2-8de9-f52eaff72852" />

Checking cache after deletion

<img width="1470" alt="Screenshot 2025-05-31 at 12 05 18 AM" src="https://github.com/user-attachments/assets/d1685ef1-03b7-443b-aee0-86a46678695e" />

# Important 
currently commented (empty function called ) out the windows api under cache.go due to build conflict , I am unable to figure out the multiple OS compile part in my IntelliJ idea , so to test out the linux api I just added a empty function to call windows.api , rest the linux delete cache function works I believe.



