### PR TITLE
bugfix: #181 files not displayed

### DIFF
--- a/internal/tui/views/clean.go
+++ b/internal/tui/views/clean.go
@@ -196,6 +196,7 @@ func InitialCleanModel(rules rules.Rules, fileManager filemanager.FileManager) *
 		FilteredCount:   0,
 		Rules:           rules,
 		Filemanager:     fileManager,
+		IsLaunched:      latestDir != "", // Set IsLaunched to true if path is already set
 	}
 
 	// Initialize tab manager


### PR DESCRIPTION
occurs because the `IsLaunched` flag in `CleanFilesModel` is only set to true when a path is manually entered, but not when initialized from rules. This flag controls whether files should be loaded in the `LoadFiles()` function.