### PR TITLE
update: remove redundant mutex usage in ScanFilesCurrentLevel

### DIFF
--- a/internal/filemanager/scanners.go
+++ b/internal/filemanager/scanners.go
@@ -90,12 +90,9 @@ func (s *FileScanner) ScanFilesCurrentLevel(dir string) (toDeleteMap map[string]
 		}
 
 		if s.filter.MatchesFilters(info, filepath.Join(dir, entry.Name())) {
-			s.mutex.Lock()
-
 			toDeleteMap[filepath.Join(dir, entry.Name())] = utils.FormatSize(info.Size())
 			totalClearSize += info.Size()
 
-			s.mutex.Unlock()
 
 			if s.haveProgress {
 				s.ProgressChan <- info.Size()


### PR DESCRIPTION
#### 🧩 Related Issue

Closes #259

#### 📝 Summary
This PR removes a redundant use of a mutex in the `ScanFilesCurrentLevel` method of `FileScanner`.
The removed mutex had no effect on correctness or thread safety, as the method doesn't share mutable state or require synchronization. The change simplifies the code and may yield minor performance improvements by avoiding unneeded locking.