### PR TITLE
test: add unit tests for ParseExtToSlice and ParseExcludeToSlice

### DIFF
--- a/internal/tests/unit/utils/utils_test.go
+++ b/internal/tests/unit/utils/utils_test.go
@@ -148,3 +148,139 @@ func TestFormatSize(t *testing.T) {
 		})
 	}
 }
+
+func TestParseExtToSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "Single extension without dot",
+			input:    "txt",
+			expected: []string{".txt"},
+		},
+		{
+			name:     "Single extension with dot",
+			input:    ".log",
+			expected: []string{".log"},
+		},
+		{
+			name:     "Multiple extensions",
+			input:    "go,txt,md",
+			expected: []string{".go", ".txt", ".md"},
+		},
+		{
+			name:     "Extensions with spaces",
+			input:    " go , txt , md ",
+			expected: []string{".go", ".txt", ".md"},
+		},
+		{
+			name:     "Mixed case extensions",
+			input:    "GO,TxT,Md",
+			expected: []string{".go", ".txt", ".md"},
+		},
+		{
+			name:     "Extensions with and without dots",
+			input:    ".go,txt,.md",
+			expected: []string{".go", ".txt", ".md"},
+		},
+		{
+			name:     "Empty elements in list",
+			input:    "go,,txt",
+			expected: []string{".go", ".txt"},
+		},
+		{
+			name:     "Spaces and empty elements",
+			input:    " , go , , txt , ",
+			expected: []string{".go", ".txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.ParseExtToSlice(tt.input)
+			
+			// Check length
+			if len(result) != len(tt.expected) {
+				t.Errorf("ParseExtToSlice(%q) length = %d, expected %d", tt.input, len(result), len(tt.expected))
+				return
+			}
+			
+			// Check each element
+			for i, exp := range tt.expected {
+				if result[i] != exp {
+					t.Errorf("ParseExtToSlice(%q)[%d] = %q, expected %q", tt.input, i, result[i], exp)
+				}
+			}
+		})
+	}
+}
+
+func TestParseExcludeToSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "Single pattern",
+			input:    "node_modules",
+			expected: []string{"node_modules"},
+		},
+		{
+			name:     "Multiple patterns",
+			input:    "node_modules,vendor,.git",
+			expected: []string{"node_modules", "vendor", ".git"},
+		},
+		{
+			name:     "Patterns with spaces",
+			input:    " node_modules , vendor , .git ",
+			expected: []string{"node_modules", "vendor", ".git"},
+		},
+		{
+			name:     "Empty elements in list",
+			input:    "node_modules,,vendor",
+			expected: []string{"node_modules", "vendor"},
+		},
+		{
+			name:     "Spaces and empty elements",
+			input:    " , node_modules , , vendor , ",
+			expected: []string{"node_modules", "vendor"},
+		},
+		{
+			name:     "Patterns with special characters",
+			input:    "*.log,test_*,!important",
+			expected: []string{"*.log", "test_*", "!important"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.ParseExcludeToSlice(tt.input)
+			
+			// Check length
+			if len(result) != len(tt.expected) {
+				t.Errorf("ParseExcludeToSlice(%q) length = %d, expected %d", tt.input, len(result), len(tt.expected))
+				return
+			}
+			
+			// Check each element
+			for i, exp := range tt.expected {
+				if result[i] != exp {
+					t.Errorf("ParseExcludeToSlice(%q)[%d] = %q, expected %q", tt.input, i, result[i], exp)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #279

Adds comprehensive table-driven unit tests for `ParseExtToSlice` and `ParseExcludeToSlice` functions in `internal/utils/utils.go`.

**Test Coverage for ParseExtToSlice:**
- Empty string input
- Single extension with and without leading dot
- Multiple extensions
- Extensions with spaces and trimming
- Mixed case (uppercase/lowercase) handling
- Empty elements in comma-separated list

**Test Coverage for ParseExcludeToSlice:**
- Empty string input
- Single and multiple exclude patterns
- Patterns with spaces and trimming
- Empty elements in comma-separated list
- Patterns with special characters (*, !)

Both test functions follow the existing table-driven test pattern used in the codebase.
