### PR TITLE
refactor: centralize file filters and harden rules handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,17 @@
 build/
 vendor/
 deletor.json
+.agents/
+.claude/
+.crush/
+.openhands/
+.serena/
+.pi/
+dogfood-output/
+docs/plans/
+task_plan.md
+findings.md
+progress.md
+.playwright-mcp/
+content/
+.omx/

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -1,31 +1,26 @@
 package config
 
 import (
-	"time"
-
+	"github.com/pashkov256/deletor/internal/filemanager"
 	"github.com/pashkov256/deletor/internal/rules"
 	"github.com/pashkov256/deletor/internal/utils"
 )
 
 // Config holds all command-line configuration options for the application
 type Config struct {
-	Directory          string    // Target directory to process
-	Extensions         []string  // File extensions to include
-	MinSize            int64     // Minimum file size in bytes
-	MaxSize            int64     // Maximum file size in bytes
-	Exclude            []string  // Patterns to exclude
-	IncludeSubdirs     bool      // Whether to process subdirectories
-	ShowProgress       bool      // Whether to display progress
-	IsCLIMode          bool      // Whether running in CLI mode
-	HaveProgress       bool      // Whether progress tracking is available
-	SkipConfirm        bool      // Whether to skip confirmation prompts
-	DeleteEmptyFolders bool      // Whether to remove empty directories
-	OlderThan          time.Time // Only process files older than this time
-	NewerThan          time.Time // Only process files newer than this time
-	MoveFileToTrash    bool      // If true, files will be moved to trash instead of being permanently deleted
-	UseRules           bool      // Whether to use rules from configuration file
-	JsonLogsEnabled    bool      // Whether to generates JSON-formatted logs
-	JsonLogsPath       string    // Path to append JSON-formatted logs
+	filemanager.FileFilterOptions
+	Directory          string   // Target directory to process
+	Extensions         []string // File extensions to include
+	IncludeSubdirs     bool     // Whether to process subdirectories
+	ShowProgress       bool     // Whether to display progress
+	IsCLIMode          bool     // Whether running in CLI mode
+	HaveProgress       bool     // Whether progress tracking is available
+	SkipConfirm        bool     // Whether to skip confirmation prompts
+	DeleteEmptyFolders bool     // Whether to remove empty directories
+	MoveFileToTrash    bool     // If true, files will be moved to trash instead of being permanently deleted
+	UseRules           bool     // Whether to use rules from configuration file
+	JsonLogsEnabled    bool     // Whether to generates JSON-formatted logs
+	JsonLogsPath       string   // Path to append JSON-formatted logs
 }
 
 // LoadConfig initializes and returns a new Config instance with values from command-line flags
@@ -36,6 +31,10 @@ func LoadConfig() *Config {
 // GetConfig returns the current configuration instance
 func (c *Config) GetConfig() *Config {
 	return c
+}
+
+func (c *Config) BuildFileFilter() *filemanager.FileFilter {
+	return filemanager.NewFileFilterWithOptions(c.FileFilterOptions, utils.ParseExtToMap(c.Extensions))
 }
 
 // GetWithRules returns a value from config if it's set, otherwise returns value from rules

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -132,7 +132,7 @@ func TestBooleanFlags(t *testing.T) {
 		check func(*config.Config) bool
 	}{
 		{"--cli", func(c *config.Config) bool { return c.IsCLIMode }},
-		{"--progress", func(c *config.Config) bool { return c.HaveProgress }}, // FIXED HERE
+		{"--progress", func(c *config.Config) bool { return c.ShowProgress && c.HaveProgress }},
 		{"--subdirs", func(c *config.Config) bool { return c.IncludeSubdirs }},
 		{"--skip-confirm", func(c *config.Config) bool { return c.SkipConfirm }},
 		{"--prune-empty", func(c *config.Config) bool { return c.DeleteEmptyFolders }},
@@ -189,6 +189,7 @@ func TestAllFlagsTogether(t *testing.T) {
 	assert.WithinDuration(t, expectedNewer, cfg.NewerThan, 5*time.Second)
 
 	assert.True(t, cfg.IsCLIMode)
+	assert.True(t, cfg.ShowProgress)
 	assert.True(t, cfg.HaveProgress)
 	assert.True(t, cfg.IncludeSubdirs)
 	assert.True(t, cfg.SkipConfirm)

--- a/internal/cli/config/flags.go
+++ b/internal/cli/config/flags.go
@@ -89,6 +89,7 @@ func GetFlags() *Config {
 	}
 
 	config.IsCLIMode = *isCLIMode
+	config.ShowProgress = *progress
 	config.HaveProgress = *progress
 	config.IncludeSubdirs = *includeSubdirsScan
 	config.Directory = *dir

--- a/internal/filemanager/filters.go
+++ b/internal/filemanager/filters.go
@@ -7,25 +7,37 @@ import (
 	"time"
 )
 
+// FileFilterOptions groups the shared runtime filter settings used by the CLI
+// config and file-scanning code.
+type FileFilterOptions struct {
+	MinSize   int64     // Minimum file size in bytes
+	MaxSize   int64     // Maximum file size in bytes
+	Exclude   []string  // Patterns to exclude from results
+	OlderThan time.Time // Only include files older than this time
+	NewerThan time.Time // Only include files newer than this time
+}
+
 // FileFilter defines criteria for filtering files
 type FileFilter struct {
-	MinSize    int64               // Minimum file size in bytes
-	MaxSize    int64               // Maximum file size in bytes
+	FileFilterOptions
 	Extensions map[string]struct{} // Set of allowed file extensions
-	Exclude    []string            // Patterns to exclude from results
-	OlderThan  time.Time           // Only include files older than this time
-	NewerThan  time.Time           // Only include files newer than this time
+}
+
+func NewFileFilterWithOptions(options FileFilterOptions, extensions map[string]struct{}) *FileFilter {
+	return &FileFilter{
+		FileFilterOptions: options,
+		Extensions:        extensions,
+	}
 }
 
 func (d *defaultFileManager) NewFileFilter(minSize, maxSize int64, extensions map[string]struct{}, exclude []string, olderThan, newerThan time.Time) *FileFilter {
-	return &FileFilter{
-		MinSize:    minSize,
-		MaxSize:    maxSize,
-		Exclude:    exclude,
-		Extensions: extensions,
-		OlderThan:  olderThan,
-		NewerThan:  newerThan,
-	}
+	return NewFileFilterWithOptions(FileFilterOptions{
+		MinSize:   minSize,
+		MaxSize:   maxSize,
+		Exclude:   exclude,
+		OlderThan: olderThan,
+		NewerThan: newerThan,
+	}, extensions)
 }
 
 // MatchesFilters checks if a file matches all filter criteria

--- a/internal/rules/interface.go
+++ b/internal/rules/interface.go
@@ -1,5 +1,7 @@
 package rules
 
+import "sync"
+
 // Rules defines the interface for managing file operation rules
 type Rules interface {
 	UpdateRules(options ...RuleOption) error // Updates rules with provided options
@@ -8,28 +10,30 @@ type Rules interface {
 	GetRulesPath() string                    // Returns path to rules configuration file
 }
 
-// defaultRules holds the configuration for file operations
+// defaultRules holds the configuration for file operations.
 type defaultRules struct {
-	Path                  string   `json:",omitempty"` // Target directory path
-	Extensions            []string `json:",omitempty"` // File extensions to process
-	Exclude               []string `json:",omitempty"` // Patterns to exclude
-	MinSize               string   `json:",omitempty"` // Minimum file size
-	MaxSize               string   `json:",omitempty"` // Maximum file size
-	OlderThan             string   `json:",omitempty"` // Only process files older than
-	NewerThan             string   `json:",omitempty"` // Only process files newer than
-	ShowHiddenFiles       bool     `json:",omitempty"` // Whether to show hidden files
-	ConfirmDeletion       bool     `json:",omitempty"` // Whether to confirm deletions
-	IncludeSubfolders     bool     `json:",omitempty"` // Whether to process subfolders
-	DeleteEmptySubfolders bool     `json:",omitempty"` // Whether to remove empty folders
-	SendFilesToTrash      bool     `json:",omitempty"` // Whether to use trash instead of delete
-	LogOperations         bool     `json:",omitempty"` // Whether to log operations
-	LogToFile             bool     `json:",omitempty"` // Whether to write logs to file
-	ShowStatistics        bool     `json:",omitempty"` // Whether to display statistics
-	DisableEmoji          bool     `json:",omitempty"` // Whether to disable emoji
-	ExitAfterDeletion     bool     `json:",omitempty"` // Whether to exit after deletion
+	Path                  string        `json:",omitempty"` // Target directory path
+	Extensions            []string      `json:",omitempty"` // File extensions to process
+	Exclude               []string      `json:",omitempty"` // Patterns to exclude
+	MinSize               string        `json:",omitempty"` // Minimum file size
+	MaxSize               string        `json:",omitempty"` // Maximum file size
+	OlderThan             string        `json:",omitempty"` // Only process files older than
+	NewerThan             string        `json:",omitempty"` // Only process files newer than
+	ShowHiddenFiles       bool          `json:",omitempty"` // Whether to show hidden files
+	ConfirmDeletion       bool          `json:",omitempty"` // Whether to confirm deletions
+	IncludeSubfolders     bool          `json:",omitempty"` // Whether to process subfolders
+	DeleteEmptySubfolders bool          `json:",omitempty"` // Whether to remove empty folders
+	SendFilesToTrash      bool          `json:",omitempty"` // Whether to use trash instead of delete
+	LogOperations         bool          `json:",omitempty"` // Whether to log operations
+	LogToFile             bool          `json:",omitempty"` // Whether to write logs to file
+	ShowStatistics        bool          `json:",omitempty"` // Whether to display statistics
+	DisableEmoji          bool          `json:",omitempty"` // Whether to disable emoji
+	ExitAfterDeletion     bool          `json:",omitempty"` // Whether to exit after deletion
+	cached                *defaultRules `json:"-"`
+	mu                    sync.RWMutex  `json:"-"`
 }
 
-// NewRules creates a new instance of the default rules
+// NewRules creates a new instance of the default rules.
 func NewRules() Rules {
 	return &defaultRules{}
 }

--- a/internal/rules/manager.go
+++ b/internal/rules/manager.go
@@ -2,101 +2,226 @@ package rules
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/pashkov256/deletor/internal/path"
 	"github.com/pashkov256/deletor/internal/tui/options"
+	"github.com/pashkov256/deletor/internal/utils"
 )
 
-// UpdateRules applies the provided options and saves the updated rules to file
-func (d *defaultRules) UpdateRules(options ...RuleOption) error {
-	// Update the struct fields
-	for _, option := range options {
-		option(d)
+func defaultRuleValues() *defaultRules {
+	return &defaultRules{
+		Path:                  "",
+		Extensions:            []string{},
+		Exclude:               []string{},
+		MinSize:               "",
+		MaxSize:               "",
+		OlderThan:             "",
+		NewerThan:             "",
+		ShowHiddenFiles:       options.DefaultCleanOptionState[options.ShowHiddenFiles],
+		ConfirmDeletion:       options.DefaultCleanOptionState[options.ConfirmDeletion],
+		IncludeSubfolders:     options.DefaultCleanOptionState[options.IncludeSubfolders],
+		DeleteEmptySubfolders: options.DefaultCleanOptionState[options.DeleteEmptySubfolders],
+		SendFilesToTrash:      options.DefaultCleanOptionState[options.SendFilesToTrash],
+		LogOperations:         options.DefaultCleanOptionState[options.LogOperations],
+		LogToFile:             options.DefaultCleanOptionState[options.LogToFile],
+		ShowStatistics:        options.DefaultCleanOptionState[options.ShowStatistics],
+		DisableEmoji:          options.DefaultCleanOptionState[options.DisableEmoji],
+		ExitAfterDeletion:     options.DefaultCleanOptionState[options.ExitAfterDeletion],
+	}
+}
+
+func (d *defaultRules) clone() *defaultRules {
+	if d == nil {
+		return defaultRuleValues()
 	}
 
-	// Marshal and save to file
-	rulesJSON, err := json.Marshal(d)
+	clone := *d
+	clone.Extensions = append([]string(nil), d.Extensions...)
+	clone.Exclude = append([]string(nil), d.Exclude...)
+	clone.cached = nil
+	return &clone
+}
+
+func (d *defaultRules) getRulesPath() (string, error) {
+	userConfigDir, err := os.UserConfigDir()
 	if err != nil {
-		return err
+		return "", fmt.Errorf("get user config dir: %w", err)
+	}
+	return filepath.Join(userConfigDir, path.AppDirName, path.RuleFileName), nil
+}
+
+func (d *defaultRules) setCache(rules *defaultRules) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.cached = rules.clone()
+}
+
+func (d *defaultRules) getCached() *defaultRules {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	if d.cached == nil {
+		return nil
+	}
+	return d.cached.clone()
+}
+
+func (d *defaultRules) validate() error {
+	if d.MinSize != "" {
+		if _, err := utils.ToBytes(d.MinSize); err != nil {
+			return fmt.Errorf("invalid MinSize: %w", err)
+		}
+	}
+	if d.MaxSize != "" {
+		if _, err := utils.ToBytes(d.MaxSize); err != nil {
+			return fmt.Errorf("invalid MaxSize: %w", err)
+		}
+	}
+	if d.OlderThan != "" {
+		if _, err := utils.ParseTimeDuration(d.OlderThan); err != nil {
+			return fmt.Errorf("invalid OlderThan: %w", err)
+		}
+	}
+	if d.NewerThan != "" {
+		if _, err := utils.ParseTimeDuration(d.NewerThan); err != nil {
+			return fmt.Errorf("invalid NewerThan: %w", err)
+		}
 	}
 
-	err = os.WriteFile(d.GetRulesPath(), rulesJSON, 0644)
-	if err != nil {
-		return err
-	}
+	d.Extensions = append([]string(nil), d.Extensions...)
+	d.Exclude = append([]string(nil), d.Exclude...)
+
 	return nil
 }
 
-// GetRules loads and returns the current rules from the configuration file
-func (d *defaultRules) GetRules() (*defaultRules, error) {
-	jsonRules, err := os.ReadFile(d.GetRulesPath())
+func (d *defaultRules) readRulesFromDisk() (*defaultRules, error) {
+	filePathRuleConfig, err := d.getRulesPath()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create a new instance to avoid modifying the receiver
-	rules := &defaultRules{}
-	err = json.Unmarshal(jsonRules, rules)
+	jsonRules, err := os.ReadFile(filePathRuleConfig)
 	if err != nil {
+		return nil, err
+	}
+
+	rules := defaultRuleValues()
+	if err := json.Unmarshal(jsonRules, rules); err != nil {
+		return nil, err
+	}
+	if err := rules.validate(); err != nil {
 		return nil, err
 	}
 
 	return rules, nil
 }
 
-// SetupRulesConfig initializes the rules configuration file with default values
-func (d *defaultRules) SetupRulesConfig() error {
-	filePathRuleConfig := d.GetRulesPath()
+func (d *defaultRules) readRulesForUpdate() (*defaultRules, error) {
+	rules, err := d.readRulesFromDisk()
+	if err == nil {
+		return rules, nil
+	}
 
-	err := os.MkdirAll(filepath.Dir(filePathRuleConfig), 0755)
+	if errors.Is(err, os.ErrNotExist) {
+		return defaultRuleValues(), nil
+	}
+
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+		return defaultRuleValues(), nil
+	}
+
+	return nil, err
+}
+
+func (d *defaultRules) writeRules(rules *defaultRules) error {
+	filePathRuleConfig, err := d.getRulesPath()
 	if err != nil {
 		return err
 	}
 
-	_, err = os.Stat(filePathRuleConfig)
-
-	if err != nil {
-		// Create a new defaultRules instance with values from DefaultCleanOptionState
-		rules := &defaultRules{
-			Path:                  "",
-			Extensions:            []string{},
-			Exclude:               []string{},
-			MinSize:               "",
-			MaxSize:               "",
-			OlderThan:             "",
-			NewerThan:             "",
-			ShowHiddenFiles:       options.DefaultCleanOptionState[options.ShowHiddenFiles],
-			ConfirmDeletion:       options.DefaultCleanOptionState[options.ConfirmDeletion],
-			IncludeSubfolders:     options.DefaultCleanOptionState[options.IncludeSubfolders],
-			DeleteEmptySubfolders: options.DefaultCleanOptionState[options.DeleteEmptySubfolders],
-			SendFilesToTrash:      options.DefaultCleanOptionState[options.SendFilesToTrash],
-			LogOperations:         options.DefaultCleanOptionState[options.LogOperations],
-			LogToFile:             options.DefaultCleanOptionState[options.LogToFile],
-			ShowStatistics:        options.DefaultCleanOptionState[options.ShowStatistics],
-			DisableEmoji:          options.DefaultCleanOptionState[options.DisableEmoji],
-			ExitAfterDeletion:     options.DefaultCleanOptionState[options.ExitAfterDeletion],
-		}
-
-		rulesJSON, err := json.Marshal(rules)
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(filePathRuleConfig, rulesJSON, 0644)
-		if err != nil {
-			return err
-		}
+	if err := os.MkdirAll(filepath.Dir(filePathRuleConfig), 0755); err != nil {
+		return err
 	}
 
+	rulesJSON, err := json.Marshal(rules)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filePathRuleConfig, rulesJSON, 0644); err != nil {
+		return err
+	}
+
+	d.setCache(rules)
 	return nil
 }
 
-// GetRulesPath returns the path to the rules configuration file
-func (d *defaultRules) GetRulesPath() string {
-	userConfigDir, _ := os.UserConfigDir()
-	filePathRuleConfig := filepath.Join(userConfigDir, path.AppDirName, path.RuleFileName)
+// UpdateRules applies the provided options and saves the updated rules to file.
+func (d *defaultRules) UpdateRules(options ...RuleOption) error {
+	currentRules, err := d.readRulesForUpdate()
+	if err != nil {
+		return err
+	}
 
+	for _, option := range options {
+		option(currentRules)
+	}
+
+	if err := currentRules.validate(); err != nil {
+		return err
+	}
+
+	return d.writeRules(currentRules)
+}
+
+// GetRules loads and returns the current rules from the configuration file.
+func (d *defaultRules) GetRules() (*defaultRules, error) {
+	if cached := d.getCached(); cached != nil {
+		return cached, nil
+	}
+
+	rules, err := d.readRulesFromDisk()
+	if err != nil {
+		return nil, err
+	}
+
+	d.setCache(rules)
+	return rules.clone(), nil
+}
+
+// SetupRulesConfig initializes the rules configuration file with default values.
+func (d *defaultRules) SetupRulesConfig() error {
+	filePathRuleConfig, err := d.getRulesPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(filePathRuleConfig), 0755); err != nil {
+		return err
+	}
+
+	_, err = os.Stat(filePathRuleConfig)
+	if err == nil {
+		_, readErr := d.readRulesFromDisk()
+		return readErr
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return d.writeRules(defaultRuleValues())
+}
+
+// GetRulesPath returns the path to the rules configuration file.
+func (d *defaultRules) GetRulesPath() string {
+	filePathRuleConfig, err := d.getRulesPath()
+	if err != nil {
+		return filepath.Join(path.AppDirName, path.RuleFileName)
+	}
 	return filePathRuleConfig
 }

--- a/internal/rules/manager.go
+++ b/internal/rules/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/pashkov256/deletor/internal/path"
 	"github.com/pashkov256/deletor/internal/tui/options"
@@ -43,6 +44,7 @@ func (d *defaultRules) clone() *defaultRules {
 	clone.Extensions = append([]string(nil), d.Extensions...)
 	clone.Exclude = append([]string(nil), d.Exclude...)
 	clone.cached = nil
+	clone.mu = sync.RWMutex{}
 	return &clone
 }
 
@@ -187,7 +189,7 @@ func (d *defaultRules) GetRules() (*defaultRules, error) {
 
 	rules, err := d.readRulesFromDisk()
 	if err != nil {
-		return nil, err
+		return defaultRuleValues(), err
 	}
 
 	d.setCache(rules)

--- a/internal/runner/cli.go
+++ b/internal/runner/cli.go
@@ -26,16 +26,7 @@ func RunCLI(
 		config = config.GetWithRules(rules)
 	}
 
-	extMap := utils.ParseExtToMap(config.Extensions)
-
-	filter := fm.NewFileFilter(
-		config.MinSize,
-		config.MaxSize,
-		extMap,
-		config.Exclude,
-		config.OlderThan,
-		config.NewerThan,
-	)
+	filter := config.BuildFileFilter()
 
 	fileScanner := filemanager.NewFileScanner(fm, filter, config.ShowProgress)
 	printer := output.NewPrinter()

--- a/internal/tests/integration/runner/cli_test.go
+++ b/internal/tests/integration/runner/cli_test.go
@@ -96,9 +96,11 @@ func TestRunCLI_BasicFileOperations(t *testing.T) {
 		{
 			name: "Delete by size",
 			config: &config.Config{
+				FileFilterOptions: filemanager.FileFilterOptions{
+					MinSize: 1,
+					MaxSize: 5,
+				},
 				Directory:      testDir,
-				MinSize:        1,
-				MaxSize:        5,
 				SkipConfirm:    true,
 				IncludeSubdirs: true,
 			},
@@ -108,8 +110,10 @@ func TestRunCLI_BasicFileOperations(t *testing.T) {
 		{
 			name: "Delete by time",
 			config: &config.Config{
+				FileFilterOptions: filemanager.FileFilterOptions{
+					OlderThan: time.Now().Add(-time.Hour),
+				},
 				Directory:       testDir,
-				OlderThan:       time.Now().Add(-time.Hour),
 				SkipConfirm:     true,
 				IncludeSubdirs:  true,
 				JsonLogsEnabled: true,
@@ -120,9 +124,11 @@ func TestRunCLI_BasicFileOperations(t *testing.T) {
 		{
 			name: "Delete with exclude",
 			config: &config.Config{
+				FileFilterOptions: filemanager.FileFilterOptions{
+					Exclude: []string{"exclude"},
+				},
 				Directory:      testDir,
 				Extensions:     []string{".txt"},
-				Exclude:        []string{"exclude"},
 				SkipConfirm:    true,
 				IncludeSubdirs: true,
 			},

--- a/internal/tests/integration/runner/cli_trash_test.go
+++ b/internal/tests/integration/runner/cli_trash_test.go
@@ -29,12 +29,14 @@ func (m *mockFileManager) MoveFileToTrash(filePath string) {
 
 func (m *mockFileManager) NewFileFilter(minSize, maxSize int64, extensions map[string]struct{}, exclude []string, olderThan, newerThan time.Time) *filemanager.FileFilter {
 	return &filemanager.FileFilter{
-		MinSize:    minSize,
-		MaxSize:    maxSize,
-		Exclude:    exclude,
+		FileFilterOptions: filemanager.FileFilterOptions{
+			MinSize:   minSize,
+			MaxSize:   maxSize,
+			Exclude:   exclude,
+			OlderThan: olderThan,
+			NewerThan: newerThan,
+		},
 		Extensions: extensions,
-		OlderThan:  olderThan,
-		NewerThan:  newerThan,
 	}
 }
 

--- a/internal/tests/tui/views/clean_test.go
+++ b/internal/tests/tui/views/clean_test.go
@@ -650,6 +650,39 @@ func TestCleanFilesModel_FileOperations(t *testing.T) {
 		}
 	})
 
+	t.Run("Refresh Preserves Directory View", func(t *testing.T) {
+		model := setupCleanTestModel(t)
+		model.Init()
+
+		for _, dir := range []string{"subdir1", "subdir2"} {
+			dirPath := filepath.Join(model.CurrentPath, dir)
+			if err := os.Mkdir(dirPath, 0755); err != nil {
+				t.Fatalf("Failed to create test directory %s: %v", dir, err)
+			}
+		}
+
+		model.ShowDirs = true
+
+		msg := model.RefreshVisibleList()()
+		items, ok := msg.([]list.Item)
+		if !ok {
+			t.Fatalf("RefreshVisibleList() did not return []list.Item")
+		}
+
+		updatedModel, _ := model.Update(items)
+		model = updatedModel.(*views.CleanFilesModel)
+
+		if !model.ShowDirs {
+			t.Fatal("expected directory view to remain active after refresh")
+		}
+		if len(model.DirList.Items()) == 0 {
+			t.Fatal("expected directories to be loaded into DirList")
+		}
+		if len(model.List.Items()) != 0 {
+			t.Fatal("expected file list to stay untouched while refreshing directories")
+		}
+	})
+
 	t.Run("Directory Size Calculation", func(t *testing.T) {
 		model := setupCleanTestModel(t)
 		model.Init()
@@ -838,6 +871,53 @@ func TestCleanFilesModel_OptionsAndSettings(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestCleanFilesModel_RefreshPreservesDirectoryMode(t *testing.T) {
+	model := setupCleanTestModel(t)
+	model.Init()
+
+	childDir := filepath.Join(model.CurrentPath, "nested")
+	if err := os.Mkdir(childDir, 0755); err != nil {
+		t.Fatalf("Failed to create nested directory: %v", err)
+	}
+
+	model.ShowDirs = true
+	model.FocusedElement = "list"
+
+	newModel, cmd := model.Handle(tea.KeyMsg{Type: tea.KeyCtrlR})
+	updatedModel, ok := newModel.(*views.CleanFilesModel)
+	if !ok {
+		t.Fatal("Failed to convert model to CleanFilesModel")
+	}
+
+	if !updatedModel.ShowDirs {
+		t.Fatal("ctrl+r should preserve directory mode before the refresh command runs")
+	}
+
+	if cmd == nil {
+		t.Fatal("ctrl+r should trigger a refresh command")
+	}
+
+	msg := cmd()
+	items, ok := msg.([]list.Item)
+	if !ok {
+		t.Fatalf("refresh command returned %T, want []list.Item", msg)
+	}
+
+	modelAfterItems, _ := updatedModel.Update(items)
+	refreshedModel, ok := modelAfterItems.(*views.CleanFilesModel)
+	if !ok {
+		t.Fatal("Failed to convert refreshed model to CleanFilesModel")
+	}
+
+	if !refreshedModel.ShowDirs {
+		t.Fatal("refreshing while browsing directories should keep ShowDirs enabled")
+	}
+
+	if len(refreshedModel.DirList.Items()) == 0 {
+		t.Fatal("directory refresh should populate the directory list")
+	}
 }
 
 func compareSlices(a, b []string) bool {

--- a/internal/tests/unit/filemanager/filters_test.go
+++ b/internal/tests/unit/filemanager/filters_test.go
@@ -126,12 +126,14 @@ func TestFileFilter_FullRequirements(t *testing.T) {
 			createTestFilesWithTimes(t, root, tt.files)
 
 			filter := &filemanager.FileFilter{
-				MinSize:    tt.minSize,
-				MaxSize:    tt.maxSize,
+				FileFilterOptions: filemanager.FileFilterOptions{
+					MinSize:   tt.minSize,
+					MaxSize:   tt.maxSize,
+					Exclude:   tt.exclude,
+					OlderThan: tt.olderThan,
+					NewerThan: tt.newerThan,
+				},
 				Extensions: tt.extensions,
-				Exclude:    tt.exclude,
-				OlderThan:  tt.olderThan,
-				NewerThan:  tt.newerThan,
 			}
 
 			for name := range tt.files {

--- a/internal/tests/unit/rules/rules_test.go
+++ b/internal/tests/unit/rules/rules_test.go
@@ -256,8 +256,8 @@ func TestUpdateRules_MultipleOptions(t *testing.T) {
 		rules.WithPath(testPath),
 		rules.WithMinSize("1GB"),
 		rules.WithMaxSize("10GB"),
-		rules.WithOlderThan("10d"),
-		rules.WithNewerThan("10d"),
+		rules.WithOlderThan("10day"),
+		rules.WithNewerThan("10day"),
 		rules.WithExtensions(testExtensions),
 		rules.WithOptions(true, true, true, false, false, true, false, true, false, false),
 		rules.WithExclude(testExclude),
@@ -345,8 +345,8 @@ func TestUpdateRules_MultipleOptions(t *testing.T) {
 	stringFields := map[string]string{
 		"MinSize":   "1GB",
 		"MaxSize":   "10GB",
-		"OlderThan": "10d",
-		"NewerThan": "10d",
+		"OlderThan": "10day",
+		"NewerThan": "10day",
 	}
 	for field, expectedValue := range stringFields {
 		if value, ok := config[field].(string); !ok || value != expectedValue {
@@ -354,6 +354,86 @@ func TestUpdateRules_MultipleOptions(t *testing.T) {
 		}
 	}
 
+}
+
+func TestUpdateRules_PreservesExistingValues(t *testing.T) {
+	cleanup := setupTempConfigDir()
+	defer cleanup()
+
+	rs := rules.NewRules()
+	if err := rs.SetupRulesConfig(); err != nil {
+		t.Fatalf("Failed to setup default config: %v", err)
+	}
+
+	if err := rs.UpdateRules(rules.WithPath("/test/path")); err != nil {
+		t.Fatalf("UpdateRules(path) failed: %v", err)
+	}
+	if err := rs.UpdateRules(rules.WithExtensions([]string{".txt", ".md"})); err != nil {
+		t.Fatalf("UpdateRules(extensions) failed: %v", err)
+	}
+
+	currentRules, err := rs.GetRules()
+	if err != nil {
+		t.Fatalf("GetRules failed: %v", err)
+	}
+
+	if currentRules.Path != "/test/path" {
+		t.Errorf("Path = %q, want %q", currentRules.Path, "/test/path")
+	}
+	if len(currentRules.Extensions) != 2 {
+		t.Fatalf("Extensions length = %d, want 2", len(currentRules.Extensions))
+	}
+	if currentRules.Extensions[0] != ".txt" || currentRules.Extensions[1] != ".md" {
+		t.Errorf("Extensions = %v, want [.txt .md]", currentRules.Extensions)
+	}
+}
+
+func TestGetRules_UsesCache(t *testing.T) {
+	cleanup := setupTempConfigDir()
+	defer cleanup()
+
+	rs := rules.NewRules()
+
+	configPath := rs.GetRulesPath()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("Failed to create config directory: %v", err)
+	}
+
+	initialConfig, err := json.Marshal(map[string]interface{}{
+		"Path": "/cached/path",
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal initial config: %v", err)
+	}
+	if err := os.WriteFile(configPath, initialConfig, 0644); err != nil {
+		t.Fatalf("Failed to write initial config: %v", err)
+	}
+
+	firstRead, err := rs.GetRules()
+	if err != nil {
+		t.Fatalf("First GetRules failed: %v", err)
+	}
+	if firstRead.Path != "/cached/path" {
+		t.Fatalf("Path = %q, want %q", firstRead.Path, "/cached/path")
+	}
+
+	replacedConfig, err := json.Marshal(map[string]interface{}{
+		"Path": "/changed/on/disk",
+	})
+	if err != nil {
+		t.Fatalf("Failed to marshal replacement config: %v", err)
+	}
+	if err := os.WriteFile(configPath, replacedConfig, 0644); err != nil {
+		t.Fatalf("Failed to overwrite config: %v", err)
+	}
+
+	cachedRead, err := rs.GetRules()
+	if err != nil {
+		t.Fatalf("Second GetRules failed: %v", err)
+	}
+	if cachedRead.Path != "/cached/path" {
+		t.Errorf("cached Path = %q, want %q", cachedRead.Path, "/cached/path")
+	}
 }
 
 func TestUpdateRules_InvalidJSON(t *testing.T) {
@@ -416,10 +496,14 @@ func TestGetRules_MissingFile(t *testing.T) {
 	configPath := rs.GetRulesPath()
 	os.RemoveAll(filepath.Dir(configPath))
 
-	// Try to get rules from the file that doesn't exist
-	_, err = rs.GetRules()
-	if err == nil {
-		t.Error("Expected error when reading non-existent file, got nil")
+	// GetRules should still return the cached configuration even if the file
+	// disappears after setup.
+	loadedRules, err := rs.GetRules()
+	if err != nil {
+		t.Fatalf("Expected cached rules when config file is removed, got error: %v", err)
+	}
+	if loadedRules == nil {
+		t.Fatal("Expected cached rules when config file is removed, got nil")
 	}
 }
 

--- a/internal/tests/unit/utils/utils_test.go
+++ b/internal/tests/unit/utils/utils_test.go
@@ -186,6 +186,9 @@ func TestParseTimeDuration(t *testing.T) {
 
 		// Upper case input (function lowercases)
 		{"uppercase", "5DAY", 5 * 24 * time.Hour, false, false},
+		{"short day", "10d", 10 * 24 * time.Hour, false, false},
+		{"short hour", "3h", 3 * time.Hour, false, false},
+		{"short month", "2mo", 2 * 30 * 24 * time.Hour, false, false},
 
 		// Edge: empty string → unitIndex==0 → returns zero time
 		{"empty string", "", 0, false, true},

--- a/internal/tests/unit/validation/validator_test.go
+++ b/internal/tests/unit/validation/validator_test.go
@@ -39,10 +39,11 @@ func TestValidator_ValidateSize(t *testing.T) {
 		{"valid size with GB", "1 gb", false},
 		{"valid size with KB", "100 kb", false},
 		{"valid size with B", "1024 b", false},
+		{"valid size with TB", "10 tb", false},
+		{"valid size uppercase", "10MB", false},
 
 		// Invalid cases
 		{"invalid format", "10m", true},
-		{"invalid unit", "10 tb", true},
 		{"empty size", "", true},
 		{"negative size", "-10 mb", true},
 		{"invalid decimal", "10.5.5 mb", true},
@@ -153,6 +154,9 @@ func TestValidateTimeDuration(t *testing.T) {
 		{"Valid no space", "5sec", nil},
 		{"Valid minimal space", "5 sec", nil},
 		{"Valid extra space", "5  sec", nil},
+		{"Valid shorthand day", "10d", nil},
+		{"Valid shorthand hour", "2h", nil},
+		{"Valid shorthand year", "1y", nil},
 		{"Newline character", "10\nsec", nil},
 		{"Tab character", "10\tsec", nil},
 		{"Unit without s", "2 year", nil},

--- a/internal/tui/views/clean.go
+++ b/internal/tui/views/clean.go
@@ -432,7 +432,7 @@ func (m *CleanFilesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 					// If this is the options.ShowHiddenFiles option, reload files
 					if option == options.ShowHiddenFiles {
-						return m, m.LoadFiles()
+						return m, m.RefreshVisibleList()
 					}
 					return m, nil
 				}
@@ -449,7 +449,7 @@ func (m *CleanFilesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.List.SetSize(msg.Width-h, listHeight)
 		m.DirList.SetSize(msg.Width-h, listHeight)
 
-		cmds = append(cmds, m.LoadFiles())
+		cmds = append(cmds, m.RefreshVisibleList())
 		cmds = append(cmds, m.CalculateDirSizeAsync())
 		return m, tea.Batch(cmds...)
 
@@ -1119,7 +1119,7 @@ func (m *CleanFilesModel) Handle(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "f5":
 		return m.handleF5()
 	case "ctrl+r":
-		return m, m.LoadFiles()
+		return m, m.RefreshVisibleList()
 	case "ctrl+s": //toogle dir mode or files mode
 		if m.ShowDirs {
 			m.ShowDirs = false
@@ -1136,7 +1136,7 @@ func (m *CleanFilesModel) Handle(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleAltC()
 	case "alt+1": // Toggle hidden files
 		m.OptionState[options.ShowHiddenFiles] = !m.OptionState[options.ShowHiddenFiles]
-		return m, m.LoadFiles()
+		return m, m.RefreshVisibleList()
 	case "alt+2": // Toggle confirm deletion
 		m.OptionState[options.ConfirmDeletion] = !m.OptionState[options.ConfirmDeletion]
 		return m, nil
@@ -1393,7 +1393,7 @@ func (m *CleanFilesModel) handleSpace() (tea.Model, tea.Cmd) {
 
 		// If this is the options.ShowHiddenFiles option, reload files
 		if optName == options.ShowHiddenFiles {
-			return m, m.LoadFiles()
+			return m, m.RefreshVisibleList()
 		}
 		return m, nil
 	}
@@ -1523,7 +1523,7 @@ func (m *CleanFilesModel) handleF5() (tea.Model, tea.Cmd) {
 func (m *CleanFilesModel) handleAltC() (tea.Model, tea.Cmd) {
 	m.MinSizeInput.SetValue("")
 	m.ExcludeInput.SetValue("")
-	return m, m.LoadFiles()
+	return m, m.RefreshVisibleList()
 }
 
 func (m *CleanFilesModel) handleEnter() (tea.Model, tea.Cmd) {
@@ -1635,7 +1635,7 @@ func (m *CleanFilesModel) handleEnter() (tea.Model, tea.Cmd) {
 				m.FocusedElement = "clean_option_" + optionNum
 
 				if optName == options.ShowHiddenFiles {
-					return m, m.LoadFiles()
+					return m, m.RefreshVisibleList()
 				}
 				return m, nil
 			}
@@ -1674,6 +1674,13 @@ func (m *CleanFilesModel) HandlePressStartButton() (tea.Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+func (m *CleanFilesModel) RefreshVisibleList() tea.Cmd {
+	if m.ShowDirs {
+		return m.LoadDirs()
+	}
+	return m.LoadFiles()
 }
 
 func (m *CleanFilesModel) blurAllInputs() {

--- a/internal/tui/views/rules.go
+++ b/internal/tui/views/rules.go
@@ -586,7 +586,7 @@ func (m *RulesModel) handleEnter() (tea.Model, tea.Cmd) {
 		}
 
 		// Save rules
-		m.rules.UpdateRules(
+		err := m.rules.UpdateRules(
 			rules.WithPath(m.LocationInput.Value()),
 			rules.WithMinSize(m.MinSizeInput.Value()),
 			rules.WithMaxSize(m.MaxSizeInput.Value()),
@@ -607,6 +607,12 @@ func (m *RulesModel) handleEnter() (tea.Model, tea.Cmd) {
 				m.OptionState[options.ExitAfterDeletion],
 			),
 		)
+		if err != nil {
+			m.SuccessSaveText = ""
+			return m, func() tea.Msg {
+				return errors.New(errors.ErrorTypeFileSystem, fmt.Sprintf("Failed to save rules: %v", err))
+			}
+		}
 		m.SuccessSaveText = "Rules saved successfully!" // Set success message
 		m.Error = nil                                   // Clear any existing error
 	} else if activeTab == 2 { // Options tab

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -294,20 +294,20 @@ func ParseTimeDuration(timeStr string) (time.Time, error) {
 
 	// Calculate the duration
 	var duration time.Duration
-	switch {
-	case strings.HasPrefix(unit, "sec"):
+	switch unit {
+	case "s", "sec", "secs", "second", "seconds":
 		duration = time.Duration(num) * time.Second
-	case strings.HasPrefix(unit, "min"):
+	case "m", "min", "mins", "minute", "minutes":
 		duration = time.Duration(num) * time.Minute
-	case strings.HasPrefix(unit, "hour"):
+	case "h", "hr", "hrs", "hour", "hours":
 		duration = time.Duration(num) * time.Hour
-	case strings.HasPrefix(unit, "day"):
+	case "d", "day", "days":
 		duration = time.Duration(num) * 24 * time.Hour
-	case strings.HasPrefix(unit, "week"):
+	case "w", "week", "weeks":
 		duration = time.Duration(num) * 7 * 24 * time.Hour
-	case strings.HasPrefix(unit, "month"):
+	case "mo", "month", "months":
 		duration = time.Duration(num) * 30 * 24 * time.Hour
-	case strings.HasPrefix(unit, "year"):
+	case "y", "year", "years":
 		duration = time.Duration(num) * 365 * 24 * time.Hour
 	default:
 		return time.Time{}, fmt.Errorf("unknown time unit: %s", unit)

--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/pashkov256/deletor/internal/utils"
 )
 
 // Validator provides methods for validating various input parameters
@@ -51,10 +53,14 @@ func (v *Validator) ValidateExtension(ext string) error {
 // ValidateSize checks if a size string is in a valid format
 // Valid format: number followed by unit (e.g., "1.5MB", "2GB")
 func (v *Validator) ValidateSize(size string) error {
-	re := regexp.MustCompile(`^\d+(\.\d+)?\s*(mb|kb|b|gb)$`)
-	if !re.MatchString(size) {
+	if strings.TrimSpace(size) == "" {
 		return errors.New("invalid size format")
 	}
+
+	if _, err := utils.ToBytes(size); err != nil {
+		return errors.New("invalid size format")
+	}
+
 	return nil
 }
 
@@ -62,8 +68,17 @@ func (v *Validator) ValidateSize(size string) error {
 // Valid format: number (optional space) followed by time unit (sec, min, hour, day, week, month, year)
 // Examples: "7days", "24 hours", "1min", "2 weeks"
 func (v *Validator) ValidateTimeDuration(timeStr string) error {
-	re := regexp.MustCompile(`^\d+\s*(sec|min|hour|day|week|month|year)s?$`)
-	if !re.MatchString(strings.ToLower(timeStr)) {
+	trimmed := strings.TrimSpace(timeStr)
+	if trimmed == "" {
+		return errors.New("expected format: number followed by time unit (sec, min, hour, day, week, month, year)")
+	}
+
+	if trimmed[0] < '0' || trimmed[0] > '9' {
+		return errors.New("expected format: number followed by time unit (sec, min, hour, day, week, month, year)")
+	}
+
+	parsedTime, err := utils.ParseTimeDuration(trimmed)
+	if err != nil || parsedTime.IsZero() {
 		return errors.New("expected format: number followed by time unit (sec, min, hour, day, week, month, year)")
 	}
 


### PR DESCRIPTION
## Summary
- centralize shared file filter state between CLI config and filemanager
- preserve rule values across partial updates, cache rules reads, and validate persisted rule data before writing
- surface rules save failures in the TUI instead of swallowing them
- preserve directory mode when refreshing the clean view and align validation with parser behavior
- fix CLI progress wiring and extend regression coverage around the parser and TUI refresh path

## Testing
- go test ./...

## Issues
Closes #153
Closes #198
Closes #205