### PR TITLE
feat: add one-off scheduled clean flow

### DIFF
--- a/internal/cleanup/one_off.go
+++ b/internal/cleanup/one_off.go
@@ -1,0 +1,166 @@
+package cleanup
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pashkov256/deletor/internal/filemanager"
+	"github.com/pashkov256/deletor/internal/rules"
+	"github.com/pashkov256/deletor/internal/utils"
+)
+
+// OneOffCleanSpec is a snapshot of the saved cleanup rules used for a
+// scheduled one-off clean run.
+type OneOffCleanSpec struct {
+	Path                  string
+	Extensions            []string
+	Exclude               []string
+	MinSize               int64
+	MaxSize               int64
+	OlderThan             time.Time
+	NewerThan             time.Time
+	IncludeSubfolders     bool
+	DeleteEmptySubfolders bool
+	SendFilesToTrash      bool
+	LogToFile             bool
+}
+
+// OneOffCleanResult captures the outcome of a scheduled clean execution.
+type OneOffCleanResult struct {
+	Path             string
+	FilesCleaned     int
+	BytesCleared     int64
+	EmptyDirsDeleted int
+	UsedTrash        bool
+	CompletedAt      time.Time
+}
+
+// LoadOneOffCleanSpec snapshots the currently saved rules for a scheduled
+// cleanup run.
+func LoadOneOffCleanSpec(ruleManager rules.Rules) (*OneOffCleanSpec, error) {
+	if ruleManager == nil {
+		return nil, errors.New("rules manager is required")
+	}
+
+	savedRules, err := ruleManager.GetRules()
+	if err != nil {
+		return nil, err
+	}
+
+	targetPath := utils.ExpandTilde(savedRules.Path)
+	if targetPath == "" {
+		return nil, errors.New("save a target path in Manage Rules before scheduling a clean")
+	}
+
+	if _, err := os.Stat(targetPath); err != nil {
+		return nil, fmt.Errorf("saved rules path is invalid: %w", err)
+	}
+
+	var minSize, maxSize int64
+	var olderThan, newerThan time.Time
+
+	if savedRules.MinSize != "" {
+		minSize, err = utils.ToBytes(savedRules.MinSize)
+		if err != nil {
+			return nil, fmt.Errorf("invalid saved minimum size: %w", err)
+		}
+	}
+
+	if savedRules.MaxSize != "" {
+		maxSize, err = utils.ToBytes(savedRules.MaxSize)
+		if err != nil {
+			return nil, fmt.Errorf("invalid saved maximum size: %w", err)
+		}
+	}
+
+	if savedRules.OlderThan != "" {
+		olderThan, err = utils.ParseTimeDuration(savedRules.OlderThan)
+		if err != nil {
+			return nil, fmt.Errorf("invalid saved older-than value: %w", err)
+		}
+	}
+
+	if savedRules.NewerThan != "" {
+		newerThan, err = utils.ParseTimeDuration(savedRules.NewerThan)
+		if err != nil {
+			return nil, fmt.Errorf("invalid saved newer-than value: %w", err)
+		}
+	}
+
+	return &OneOffCleanSpec{
+		Path:                  targetPath,
+		Extensions:            append([]string(nil), savedRules.Extensions...),
+		Exclude:               append([]string(nil), savedRules.Exclude...),
+		MinSize:               minSize,
+		MaxSize:               maxSize,
+		OlderThan:             olderThan,
+		NewerThan:             newerThan,
+		IncludeSubfolders:     savedRules.IncludeSubfolders,
+		DeleteEmptySubfolders: savedRules.DeleteEmptySubfolders,
+		SendFilesToTrash:      savedRules.SendFilesToTrash,
+		LogToFile:             savedRules.LogToFile,
+	}, nil
+}
+
+// RunOneOffClean executes a one-off cleanup run using a previously loaded
+// cleanup spec.
+func RunOneOffClean(fm filemanager.FileManager, spec *OneOffCleanSpec) (*OneOffCleanResult, error) {
+	if fm == nil {
+		return nil, errors.New("file manager is required")
+	}
+	if spec == nil {
+		return nil, errors.New("cleanup spec is required")
+	}
+
+	filter := fm.NewFileFilter(
+		spec.MinSize,
+		spec.MaxSize,
+		utils.ParseExtToMap(spec.Extensions),
+		spec.Exclude,
+		spec.OlderThan,
+		spec.NewerThan,
+	)
+
+	scanner := filemanager.NewFileScanner(fm, filter, false)
+
+	var toClean map[string]string
+	var totalBytes int64
+
+	if spec.IncludeSubfolders {
+		toClean, totalBytes = scanner.ScanFilesRecursively(spec.Path)
+	} else {
+		toClean, totalBytes = scanner.ScanFilesCurrentLevel(spec.Path)
+	}
+
+	for filePath := range toClean {
+		if spec.SendFilesToTrash {
+			fm.MoveFileToTrash(filePath)
+		} else {
+			fm.DeleteFile(filePath)
+		}
+	}
+
+	emptyDirsDeleted := 0
+	if spec.DeleteEmptySubfolders {
+		emptyDirs := scanner.ScanEmptySubFolders(spec.Path)
+		emptyDirsDeleted = len(emptyDirs)
+		if emptyDirsDeleted > 0 {
+			fm.DeleteEmptySubfolders(spec.Path)
+		}
+	}
+
+	if spec.LogToFile && len(toClean) > 0 {
+		utils.LogDeletionToFile(toClean)
+	}
+
+	return &OneOffCleanResult{
+		Path:             spec.Path,
+		FilesCleaned:     len(toClean),
+		BytesCleared:     totalBytes,
+		EmptyDirsDeleted: emptyDirsDeleted,
+		UsedTrash:        spec.SendFilesToTrash,
+		CompletedAt:      time.Now(),
+	}, nil
+}

--- a/internal/tests/tui/views/schedule_test.go
+++ b/internal/tests/tui/views/schedule_test.go
@@ -1,0 +1,118 @@
+package views_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	zone "github.com/lrstanley/bubblezone"
+	"github.com/pashkov256/deletor/internal/filemanager"
+	"github.com/pashkov256/deletor/internal/path"
+	"github.com/pashkov256/deletor/internal/rules"
+	"github.com/pashkov256/deletor/internal/tui/views"
+	"github.com/pashkov256/deletor/internal/validation"
+)
+
+func setupScheduleRulesConfig(t *testing.T) func() {
+	t.Helper()
+
+	origAppDirName := path.AppDirName
+	origRuleFileName := path.RuleFileName
+
+	path.AppDirName = "deletor_schedule_view_test"
+	path.RuleFileName = "rule_schedule_view_test.json"
+
+	return func() {
+		userConfigDir, _ := os.UserConfigDir()
+		_ = os.RemoveAll(filepath.Join(userConfigDir, path.AppDirName))
+		path.AppDirName = origAppDirName
+		path.RuleFileName = origRuleFileName
+	}
+}
+
+func setupScheduleModel(t *testing.T) (*views.ScheduleCleanModel, string) {
+	t.Helper()
+
+	cleanupConfig := setupScheduleRulesConfig(t)
+	t.Cleanup(cleanupConfig)
+
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "delete.txt"), []byte("delete"), 0644); err != nil {
+		t.Fatalf("Failed to create delete.txt: %v", err)
+	}
+
+	ruleManager := rules.NewRules()
+	if err := ruleManager.SetupRulesConfig(); err != nil {
+		t.Fatalf("Failed to setup rules: %v", err)
+	}
+	if err := ruleManager.UpdateRules(
+		rules.WithPath(tempDir),
+		rules.WithExtensions([]string{".txt"}),
+		rules.WithOptions(false, false, false, false, false, false, false, false, false, false),
+	); err != nil {
+		t.Fatalf("Failed to update rules: %v", err)
+	}
+
+	model := views.NewScheduleCleanModel(ruleManager, filemanager.NewFileManager(), validation.NewValidator())
+	model.Init()
+	return model, tempDir
+}
+
+func TestScheduleCleanModel_View(t *testing.T) {
+	zone.NewGlobal()
+	model, _ := setupScheduleModel(t)
+
+	view := model.View()
+	if !strings.Contains(view, "Schedule one-off clean") {
+		t.Fatal("expected schedule page title in view")
+	}
+	if !strings.Contains(view, "Run in:") {
+		t.Fatal("expected delay input in view")
+	}
+}
+
+func TestScheduleCleanModel_SchedulesAndRunsOneOffClean(t *testing.T) {
+	model, tempDir := setupScheduleModel(t)
+	model.DelayInput.SetValue("1 sec")
+	model.FocusedElement = "scheduleButton"
+
+	newModel, cmd := model.Handle(tea.KeyMsg{Type: tea.KeyEnter})
+	scheduleModel, ok := newModel.(*views.ScheduleCleanModel)
+	if !ok {
+		t.Fatal("failed to convert scheduled model")
+	}
+	if cmd == nil {
+		t.Fatal("expected schedule command")
+	}
+	if !scheduleModel.IsScheduled() {
+		t.Fatal("expected model to hold a scheduled run")
+	}
+	if scheduleModel.GetScheduledFor().IsZero() {
+		t.Fatal("expected scheduled-for timestamp to be set")
+	}
+
+	triggeredModel, runCmd := scheduleModel.Update(views.ScheduledCleanTriggerMsg{ScheduleID: 1})
+	scheduleModel = triggeredModel.(*views.ScheduleCleanModel)
+	if !scheduleModel.IsRunning() {
+		t.Fatal("expected model to enter running state")
+	}
+	if runCmd == nil {
+		t.Fatal("expected cleanup command after trigger")
+	}
+
+	completedMsg := runCmd()
+	completedModel, _ := scheduleModel.Update(completedMsg)
+	scheduleModel = completedModel.(*views.ScheduleCleanModel)
+
+	if scheduleModel.IsRunning() || scheduleModel.IsScheduled() {
+		t.Fatal("expected scheduled run state to clear after completion")
+	}
+	if !strings.Contains(scheduleModel.GetStatus(), "Deleted 1 file(s)") {
+		t.Fatalf("unexpected completion status: %q", scheduleModel.GetStatus())
+	}
+	if _, err := os.Stat(filepath.Join(tempDir, "delete.txt")); !os.IsNotExist(err) {
+		t.Fatal("delete.txt should be removed after scheduled clean")
+	}
+}

--- a/internal/tests/unit/cleanup/one_off_test.go
+++ b/internal/tests/unit/cleanup/one_off_test.go
@@ -1,0 +1,145 @@
+package cleanup_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pashkov256/deletor/internal/cleanup"
+	"github.com/pashkov256/deletor/internal/filemanager"
+	"github.com/pashkov256/deletor/internal/path"
+	"github.com/pashkov256/deletor/internal/rules"
+)
+
+func setupCleanupRulesConfig(t *testing.T) func() {
+	t.Helper()
+
+	origAppDirName := path.AppDirName
+	origRuleFileName := path.RuleFileName
+
+	path.AppDirName = "deletor_schedule_test"
+	path.RuleFileName = "rule_schedule_test.json"
+
+	return func() {
+		userConfigDir, _ := os.UserConfigDir()
+		_ = os.RemoveAll(filepath.Join(userConfigDir, path.AppDirName))
+		path.AppDirName = origAppDirName
+		path.RuleFileName = origRuleFileName
+	}
+}
+
+func TestRunOneOffClean_UsesSavedRulesRecursively(t *testing.T) {
+	cleanupConfig := setupCleanupRulesConfig(t)
+	defer cleanupConfig()
+
+	rootDir := t.TempDir()
+	nestedDir := filepath.Join(rootDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("Failed to create nested dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(rootDir, "keep.log"), []byte("keep"), 0644); err != nil {
+		t.Fatalf("Failed to create keep.log: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "delete.txt"), []byte("delete"), 0644); err != nil {
+		t.Fatalf("Failed to create delete.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatalf("Failed to create nested.txt: %v", err)
+	}
+
+	ruleManager := rules.NewRules()
+	if err := ruleManager.SetupRulesConfig(); err != nil {
+		t.Fatalf("Failed to setup rules: %v", err)
+	}
+
+	if err := ruleManager.UpdateRules(
+		rules.WithPath(rootDir),
+		rules.WithExtensions([]string{".txt"}),
+		rules.WithOptions(false, false, true, true, false, false, false, false, false, false),
+	); err != nil {
+		t.Fatalf("Failed to update rules: %v", err)
+	}
+
+	spec, err := cleanup.LoadOneOffCleanSpec(ruleManager)
+	if err != nil {
+		t.Fatalf("LoadOneOffCleanSpec failed: %v", err)
+	}
+
+	result, err := cleanup.RunOneOffClean(filemanager.NewFileManager(), spec)
+	if err != nil {
+		t.Fatalf("RunOneOffClean failed: %v", err)
+	}
+
+	if result.FilesCleaned != 2 {
+		t.Fatalf("FilesCleaned = %d, want 2", result.FilesCleaned)
+	}
+	if result.UsedTrash {
+		t.Fatal("Expected permanent delete mode")
+	}
+	if result.EmptyDirsDeleted == 0 {
+		t.Fatal("Expected at least one empty directory to be deleted")
+	}
+
+	if _, err := os.Stat(filepath.Join(rootDir, "delete.txt")); !os.IsNotExist(err) {
+		t.Fatal("delete.txt should be removed")
+	}
+	if _, err := os.Stat(filepath.Join(nestedDir, "nested.txt")); !os.IsNotExist(err) {
+		t.Fatal("nested.txt should be removed")
+	}
+	if _, err := os.Stat(filepath.Join(rootDir, "keep.log")); err != nil {
+		t.Fatalf("keep.log should remain: %v", err)
+	}
+	if _, err := os.Stat(nestedDir); !os.IsNotExist(err) {
+		t.Fatal("nested directory should be pruned after the clean")
+	}
+}
+
+func TestRunOneOffClean_RespectsCurrentLevelOnly(t *testing.T) {
+	cleanupConfig := setupCleanupRulesConfig(t)
+	defer cleanupConfig()
+
+	rootDir := t.TempDir()
+	nestedDir := filepath.Join(rootDir, "nested")
+	if err := os.MkdirAll(nestedDir, 0755); err != nil {
+		t.Fatalf("Failed to create nested dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(rootDir, "delete.txt"), []byte("delete"), 0644); err != nil {
+		t.Fatalf("Failed to create delete.txt: %v", err)
+	}
+	nestedPath := filepath.Join(nestedDir, "nested.txt")
+	if err := os.WriteFile(nestedPath, []byte("nested"), 0644); err != nil {
+		t.Fatalf("Failed to create nested.txt: %v", err)
+	}
+
+	ruleManager := rules.NewRules()
+	if err := ruleManager.SetupRulesConfig(); err != nil {
+		t.Fatalf("Failed to setup rules: %v", err)
+	}
+
+	if err := ruleManager.UpdateRules(
+		rules.WithPath(rootDir),
+		rules.WithExtensions([]string{".txt"}),
+		rules.WithOptions(false, false, false, false, false, false, false, false, false, false),
+	); err != nil {
+		t.Fatalf("Failed to update rules: %v", err)
+	}
+
+	spec, err := cleanup.LoadOneOffCleanSpec(ruleManager)
+	if err != nil {
+		t.Fatalf("LoadOneOffCleanSpec failed: %v", err)
+	}
+
+	result, err := cleanup.RunOneOffClean(filemanager.NewFileManager(), spec)
+	if err != nil {
+		t.Fatalf("RunOneOffClean failed: %v", err)
+	}
+
+	if result.FilesCleaned != 1 {
+		t.Fatalf("FilesCleaned = %d, want 1", result.FilesCleaned)
+	}
+	if _, err := os.Stat(nestedPath); err != nil {
+		t.Fatalf("nested file should remain when subfolders are disabled: %v", err)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -18,6 +18,7 @@ const (
 	cleanPage
 	cachePage
 	rulesPage
+	schedulePage
 	statsPage
 )
 
@@ -27,6 +28,7 @@ type App struct {
 	cleanFilesModel *views.CleanFilesModel
 	rulesModel      *views.RulesModel
 	cacheModel      *views.CacheModel
+	scheduleModel   *views.ScheduleCleanModel
 	filemanager     filemanager.FileManager
 	rules           rules.Rules
 	validator       *validation.Validator
@@ -38,19 +40,20 @@ func NewApp(
 	validator *validation.Validator,
 ) *App {
 	return &App{
-		menu:        views.NewMainMenu(rules),
-		rulesModel:  views.NewRulesModel(rules, validator),
-		page:        menuPage,
-		filemanager: filemanager,
-		rules:       rules,
-		validator:   validator,
+		menu:          views.NewMainMenu(rules),
+		rulesModel:    views.NewRulesModel(rules, validator),
+		scheduleModel: views.NewScheduleCleanModel(rules, filemanager, validator),
+		page:          menuPage,
+		filemanager:   filemanager,
+		rules:         rules,
+		validator:     validator,
 	}
 }
 
 func (a *App) Init() tea.Cmd {
 	a.cleanFilesModel = views.InitialCleanModel(a.rules, a.filemanager, a.validator)
 	a.cacheModel = views.InitialCacheModel(a.filemanager, a.rules)
-	return tea.Batch(a.menu.Init(), a.cleanFilesModel.Init(), a.rulesModel.Init())
+	return tea.Batch(a.menu.Init(), a.cleanFilesModel.Init(), a.rulesModel.Init(), a.scheduleModel.Init())
 }
 
 func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -82,7 +85,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					a.page = cachePage
 				case menu.ManageRulesTitle:
 					a.page = rulesPage
-
+				case menu.ScheduleCleanTitle:
+					a.page = schedulePage
 				case menu.ExitTitle:
 					return a, tea.Quit
 				}
@@ -93,6 +97,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.menu = views.NewMainMenu(a.rules)
 		a.cacheModel = views.InitialCacheModel(a.filemanager, a.rules)
 		return a, nil
+	case views.ScheduledCleanTriggerMsg, views.ScheduledCleanCompletedMsg:
+		scheduleModel, scheduleCmd := a.scheduleModel.Update(msg)
+		if m, ok := scheduleModel.(*views.ScheduleCleanModel); ok {
+			a.scheduleModel = m
+		}
+		return a, scheduleCmd
 	}
 
 	switch a.page {
@@ -119,6 +129,12 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.rulesModel = r
 		}
 		cmd = rulesCmd
+	case schedulePage:
+		scheduleModel, scheduleCmd := a.scheduleModel.Update(msg)
+		if s, ok := scheduleModel.(*views.ScheduleCleanModel); ok {
+			a.scheduleModel = s
+		}
+		cmd = scheduleCmd
 	}
 
 	return a, tea.Batch(cmd, tea.Batch(cmds...))
@@ -135,6 +151,8 @@ func (a *App) View() string {
 		content = a.cacheModel.View()
 	case rulesPage:
 		content = a.rulesModel.View()
+	case schedulePage:
+		content = a.scheduleModel.View()
 	}
 
 	return styles.AppStyle.Render(content)

--- a/internal/tui/menu/constants.go
+++ b/internal/tui/menu/constants.go
@@ -1,16 +1,18 @@
 package menu
 
 var (
-	CleanFIlesTitle  = "🧹 Clean files"
-	CleanCacheTitle  = "♻️ Clean cache"
-	ManageRulesTitle = "⚙️ Manage rules"
-	StatisticsTitle  = "📊 Statistics"
-	ExitTitle        = "🚪 Exit"
+	CleanFIlesTitle    = "🧹 Clean files"
+	CleanCacheTitle    = "♻️ Clean cache"
+	ManageRulesTitle   = "⚙️ Manage rules"
+	ScheduleCleanTitle = "⏰ Schedule one-off clean"
+	StatisticsTitle    = "📊 Statistics"
+	ExitTitle          = "🚪 Exit"
 )
 
 var MenuItems = []string{
 	CleanFIlesTitle,
 	CleanCacheTitle,
 	ManageRulesTitle,
+	ScheduleCleanTitle,
 	ExitTitle,
 }

--- a/internal/tui/views/menu.go
+++ b/internal/tui/views/menu.go
@@ -61,7 +61,7 @@ func (m *MainMenu) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseMsg:
 		if msg.Action == tea.MouseActionRelease && msg.Button == tea.MouseButtonLeft {
 			// Check each menu item for click
-			for i := 0; i < 5; i++ {
+			for i := 0; i < len(menu.MenuItems); i++ {
 				if zone.Get(fmt.Sprintf("menu_button_%d", i)).InBounds(msg) {
 					m.SelectedIndex = i
 					// Emulate Enter key press

--- a/internal/tui/views/schedule.go
+++ b/internal/tui/views/schedule.go
@@ -1,0 +1,338 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	zone "github.com/lrstanley/bubblezone"
+	"github.com/pashkov256/deletor/internal/cleanup"
+	"github.com/pashkov256/deletor/internal/filemanager"
+	"github.com/pashkov256/deletor/internal/rules"
+	"github.com/pashkov256/deletor/internal/tui/errors"
+	"github.com/pashkov256/deletor/internal/tui/help"
+	"github.com/pashkov256/deletor/internal/tui/styles"
+	"github.com/pashkov256/deletor/internal/utils"
+	"github.com/pashkov256/deletor/internal/validation"
+)
+
+// ScheduledCleanTriggerMsg fires when a scheduled cleanup timer elapses.
+type ScheduledCleanTriggerMsg struct {
+	ScheduleID int
+}
+
+// ScheduledCleanCompletedMsg reports the result of a scheduled cleanup run.
+type ScheduledCleanCompletedMsg struct {
+	ScheduleID int
+	Result     *cleanup.OneOffCleanResult
+	Err        error
+}
+
+// ScheduleCleanModel manages the one-off scheduled clean page.
+type ScheduleCleanModel struct {
+	DelayInput       textinput.Model
+	FocusedElement   string
+	rules            rules.Rules
+	filemanager      filemanager.FileManager
+	validator        *validation.Validator
+	pendingSpec      *cleanup.OneOffCleanSpec
+	scheduledFor     time.Time
+	activeScheduleID int
+	isScheduled      bool
+	isRunning        bool
+	status           string
+	Error            *errors.Error
+}
+
+func NewScheduleCleanModel(ruleManager rules.Rules, fm filemanager.FileManager, validator *validation.Validator) *ScheduleCleanModel {
+	delayInput := textinput.New()
+	delayInput.Placeholder = "Run in (e.g. 10 min, 1 hour, 1 day)"
+	delayInput.PromptStyle = styles.TextInputPromptStyle
+	delayInput.TextStyle = styles.TextInputTextStyle
+	delayInput.Cursor.Style = styles.TextInputCursorStyle
+
+	return &ScheduleCleanModel{
+		DelayInput:     delayInput,
+		FocusedElement: "delayInput",
+		rules:          ruleManager,
+		filemanager:    fm,
+		validator:      validator,
+	}
+}
+
+func (m *ScheduleCleanModel) Init() tea.Cmd {
+	m.DelayInput.Focus()
+	return textinput.Blink
+}
+
+func (m *ScheduleCleanModel) View() string {
+	var content strings.Builder
+
+	content.WriteString(styles.TitleStyle.Render("Schedule one-off clean"))
+	content.WriteString("\n\n")
+	content.WriteString("This schedules a single future cleanup run using your saved rules.\n")
+	content.WriteString("Deletor must stay open until the scheduled time.\n\n")
+
+	spec, specErr := cleanup.LoadOneOffCleanSpec(m.rules)
+	if specErr != nil {
+		content.WriteString(styles.InfoStyle.Render(specErr.Error()))
+		content.WriteString("\n\n")
+	} else {
+		extensions := "all files"
+		if len(spec.Extensions) > 0 {
+			extensions = strings.Join(spec.Extensions, ", ")
+		}
+
+		scope := "current directory only"
+		if spec.IncludeSubfolders {
+			scope = "current directory and subfolders"
+		}
+
+		action := "delete permanently"
+		if spec.SendFilesToTrash {
+			action = "move files to trash"
+		}
+
+		content.WriteString(fmt.Sprintf("Saved path: %s\n", spec.Path))
+		content.WriteString(fmt.Sprintf("Extensions: %s\n", extensions))
+		content.WriteString(fmt.Sprintf("Scope: %s\n", scope))
+		content.WriteString(fmt.Sprintf("Action: %s\n", action))
+		if spec.DeleteEmptySubfolders {
+			content.WriteString("Empty directories will be pruned after the run.\n")
+		}
+		content.WriteString("\n")
+	}
+
+	delayStyle := styles.StandardInputStyle
+	if m.FocusedElement == "delayInput" {
+		delayStyle = styles.StandardInputFocusedStyle
+	}
+	content.WriteString(zone.Mark("schedule_delay_input", delayStyle.Render("Run in: "+m.DelayInput.View())))
+	content.WriteString("\n\n")
+
+	buttonLabel := "Schedule one-off clean"
+	buttonStyle := styles.StandardButtonStyle
+	if m.FocusedElement == "scheduleButton" {
+		buttonStyle = styles.StandardButtonFocusedStyle
+	}
+	if m.isRunning {
+		buttonLabel = "Running scheduled clean..."
+		buttonStyle = styles.LaunchButtonFocusedStyle
+	}
+	content.WriteString(zone.Mark("schedule_button", buttonStyle.Render(buttonLabel)))
+
+	if m.isScheduled {
+		content.WriteString("\n\n")
+		content.WriteString(styles.InfoStyle.Render(
+			fmt.Sprintf("Scheduled for %s", m.scheduledFor.Format("2006-01-02 15:04:05")),
+		))
+	}
+
+	if m.Error != nil && m.Error.IsVisible() {
+		content.WriteString("\n\n")
+		content.WriteString(errors.GetStyle(m.Error.GetType()).Render(m.Error.GetMessage()))
+	} else if m.status != "" {
+		content.WriteString("\n\n")
+		content.WriteString(styles.SuccessStyle.Render(m.status))
+	}
+
+	content.WriteString("\n\n")
+	content.WriteString(help.NavigateHelpText)
+
+	return zone.Scan(content.String())
+}
+
+func (m *ScheduleCleanModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.Handle(msg)
+	case tea.MouseMsg:
+		// nolint:staticcheck
+		if msg.Type == tea.MouseLeft && msg.Action == tea.MouseActionPress {
+			if zone.Get("schedule_delay_input").InBounds(msg) {
+				m.FocusedElement = "delayInput"
+				m.DelayInput.Focus()
+				return m, nil
+			}
+			if zone.Get("schedule_button").InBounds(msg) {
+				m.FocusedElement = "scheduleButton"
+				m.DelayInput.Blur()
+				return m.scheduleOnce()
+			}
+		}
+	case ScheduledCleanTriggerMsg:
+		if msg.ScheduleID != m.activeScheduleID || m.pendingSpec == nil {
+			return m, nil
+		}
+		m.isScheduled = false
+		m.isRunning = true
+		m.Error = nil
+		m.status = "Running scheduled clean..."
+		return m, m.runScheduledClean(msg.ScheduleID)
+	case ScheduledCleanCompletedMsg:
+		if msg.ScheduleID != m.activeScheduleID {
+			return m, nil
+		}
+
+		m.isRunning = false
+		m.pendingSpec = nil
+		m.activeScheduleID = 0
+		m.scheduledFor = time.Time{}
+
+		if msg.Err != nil {
+			m.status = ""
+			m.Error = errors.New(errors.ErrorTypeFileSystem, fmt.Sprintf("Scheduled clean failed: %v", msg.Err))
+			return m, nil
+		}
+
+		m.Error = nil
+		if msg.Result == nil {
+			m.status = "Scheduled clean completed."
+			return m, nil
+		}
+
+		action := "Deleted"
+		if msg.Result.UsedTrash {
+			action = "Moved to trash"
+		}
+
+		status := fmt.Sprintf(
+			"%s %d file(s), cleared %s.",
+			action,
+			msg.Result.FilesCleaned,
+			utils.FormatSize(msg.Result.BytesCleared),
+		)
+		if msg.Result.EmptyDirsDeleted > 0 {
+			status += fmt.Sprintf(" Removed %d empty directorie(s).", msg.Result.EmptyDirsDeleted)
+		}
+		m.status = status
+		return m, nil
+	}
+
+	if m.FocusedElement == "delayInput" {
+		var cmd tea.Cmd
+		m.DelayInput, cmd = m.DelayInput.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *ScheduleCleanModel) Handle(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "tab", "down":
+		return m.focusNext()
+	case "shift+tab", "up":
+		return m.focusPrevious()
+	case "enter":
+		if m.FocusedElement == "scheduleButton" {
+			return m.scheduleOnce()
+		}
+	case "alt+c":
+		m.DelayInput.SetValue("")
+		if !m.isScheduled && !m.isRunning {
+			m.status = ""
+		}
+		m.Error = nil
+		return m, nil
+	}
+
+	if m.FocusedElement == "delayInput" {
+		var cmd tea.Cmd
+		m.DelayInput, cmd = m.DelayInput.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *ScheduleCleanModel) focusNext() (tea.Model, tea.Cmd) {
+	if m.FocusedElement == "delayInput" {
+		m.FocusedElement = "scheduleButton"
+		m.DelayInput.Blur()
+	} else {
+		m.FocusedElement = "delayInput"
+		m.DelayInput.Focus()
+	}
+	return m, nil
+}
+
+func (m *ScheduleCleanModel) focusPrevious() (tea.Model, tea.Cmd) {
+	return m.focusNext()
+}
+
+func (m *ScheduleCleanModel) scheduleOnce() (tea.Model, tea.Cmd) {
+	if err := m.validator.ValidateTimeDuration(m.DelayInput.Value()); err != nil {
+		m.status = ""
+		return m, func() tea.Msg {
+			return errors.New(errors.ErrorTypeValidation, "Invalid schedule delay format")
+		}
+	}
+
+	spec, err := cleanup.LoadOneOffCleanSpec(m.rules)
+	if err != nil {
+		m.status = ""
+		return m, func() tea.Msg {
+			return errors.New(errors.ErrorTypeValidation, err.Error())
+		}
+	}
+
+	parsedTime, err := utils.ParseTimeDuration(m.DelayInput.Value())
+	if err != nil {
+		m.status = ""
+		return m, func() tea.Msg {
+			return errors.New(errors.ErrorTypeValidation, fmt.Sprintf("Invalid schedule delay: %v", err))
+		}
+	}
+
+	delay := time.Since(parsedTime)
+	if delay <= 0 {
+		m.status = ""
+		return m, func() tea.Msg {
+			return errors.New(errors.ErrorTypeValidation, "Schedule delay must be greater than zero")
+		}
+	}
+
+	m.activeScheduleID++
+	m.pendingSpec = spec
+	m.scheduledFor = time.Now().Add(delay)
+	m.isScheduled = true
+	m.isRunning = false
+	m.Error = nil
+	m.status = fmt.Sprintf("One-off clean scheduled for %s", m.scheduledFor.Format("2006-01-02 15:04:05"))
+
+	scheduleID := m.activeScheduleID
+	return m, tea.Tick(delay, func(time.Time) tea.Msg {
+		return ScheduledCleanTriggerMsg{ScheduleID: scheduleID}
+	})
+}
+
+func (m *ScheduleCleanModel) runScheduledClean(scheduleID int) tea.Cmd {
+	spec := m.pendingSpec
+	return func() tea.Msg {
+		result, err := cleanup.RunOneOffClean(m.filemanager, spec)
+		return ScheduledCleanCompletedMsg{
+			ScheduleID: scheduleID,
+			Result:     result,
+			Err:        err,
+		}
+	}
+}
+
+func (m *ScheduleCleanModel) IsScheduled() bool {
+	return m.isScheduled
+}
+
+func (m *ScheduleCleanModel) IsRunning() bool {
+	return m.isRunning
+}
+
+func (m *ScheduleCleanModel) GetStatus() string {
+	return m.status
+}
+
+func (m *ScheduleCleanModel) GetScheduledFor() time.Time {
+	return m.scheduledFor
+}


### PR DESCRIPTION
## Summary
- add a dedicated TUI page for scheduling a single future clean run
- snapshot the saved rules, then execute the clean once when the timer fires
- keep the schedule session-bound so the run happens while Deletor stays open
- add cleanup and TUI coverage for the new one-off scheduling flow

## Testing
- go test ./...

## Issue
Closes #238