### PR TITLE
 implementation of a reporting feature and dry-run mode for the CLI

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	UseRules           bool     // Whether to use rules from configuration file
 	JsonLogsEnabled    bool     // Whether to generates JSON-formatted logs
 	JsonLogsPath       string   // Path to append JSON-formatted logs
+	ReportPath         string   // Path to export report
+	ReportFormat       string   // Format of the report (json or csv)
+	DryRun             bool     // If true, no files will be deleted
 }
 
 // LoadConfig initializes and returns a new Config instance with values from command-line flags

--- a/internal/cli/config/flags.go
+++ b/internal/cli/config/flags.go
@@ -27,6 +27,9 @@ func GetFlags() *Config {
 	moveToTrash := flag.Bool("trash", false, "Move files to trash?")
 	useRules := flag.Bool("rules", false, "Use rules from configuration file")
 	jsonLogsEnabled := flag.Bool("log-json", false, "Enable JSON-formatted logging. Use --log-json or --log-json \"/path/to/file\" to specify a path to write logs.")
+	reportPath := flag.String("report", "", "Export a report of files selected and action taken/planned to a specified path")
+	reportFormat := flag.String("report-format", "json", "Format of the report (json or csv)")
+	dryRun := flag.Bool("dry-run", false, "Perform a dry run without actually deleting or moving files")
 
 	flag.Parse()
 
@@ -97,6 +100,9 @@ func GetFlags() *Config {
 	config.DeleteEmptyFolders = *deleteEmptyFolders
 	config.MoveFileToTrash = *moveToTrash
 	config.UseRules = *useRules
+	config.ReportPath = *reportPath
+	config.ReportFormat = *reportFormat
+	config.DryRun = *dryRun
 
 	return config
 }

--- a/internal/runner/cli.go
+++ b/internal/runner/cli.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/pashkov256/deletor/internal/cli/config"
 	"github.com/pashkov256/deletor/internal/cli/output"
@@ -37,6 +38,7 @@ func RunCLI(
 
 	var toDeleteMap map[string]string
 	var totalClearSize int64
+	var reportEntries []utils.ReportEntry
 
 	if config.IncludeSubdirs {
 		toDeleteMap, totalClearSize = fileScanner.ScanFilesRecursively(config.Directory)
@@ -61,22 +63,50 @@ func RunCLI(
 		}
 
 		if actionIsDelete {
+			actionName := "delete"
 			if config.MoveFileToTrash {
-				for path := range toDeleteMap {
-					fm.MoveFileToTrash(path)
-				}
-				printer.PrintSuccess("Moved to trash: %s", utils.FormatSize(totalClearSize))
-			} else {
-				for path := range toDeleteMap {
-					fm.DeleteFile(path)
-				}
-				printer.PrintSuccess("Deleted: %s", utils.FormatSize(totalClearSize))
+				actionName = "trash"
+			}
+			if config.DryRun {
+				actionName = "planned " + actionName
 			}
 
-			if config.JsonLogsEnabled {
-				utils.LogDeletionToFileAsJson(toDeleteMap, config.JsonLogsPath)
+			for path := range toDeleteMap {
+				if config.ReportPath != "" {
+					info, err := os.Stat(path)
+					if err == nil {
+						reportEntries = append(reportEntries, utils.ReportEntry{
+							Path:      path,
+							Action:    actionName,
+							Size:      info.Size(),
+							Timestamp: info.ModTime(),
+						})
+					}
+				}
+
+				if !config.DryRun {
+					if config.MoveFileToTrash {
+						fm.MoveFileToTrash(path)
+					} else {
+						fm.DeleteFile(path)
+					}
+				}
+			}
+
+			if !config.DryRun {
+				if config.MoveFileToTrash {
+					printer.PrintSuccess("Moved to trash: %s", utils.FormatSize(totalClearSize))
+				} else {
+					printer.PrintSuccess("Deleted: %s", utils.FormatSize(totalClearSize))
+				}
+
+				if config.JsonLogsEnabled {
+					utils.LogDeletionToFileAsJson(toDeleteMap, config.JsonLogsPath)
+				} else {
+					utils.LogDeletionToFile(toDeleteMap)
+				}
 			} else {
-				utils.LogDeletionToFile(toDeleteMap)
+				printer.PrintInfo("Dry run: no files were actually deleted or moved.")
 			}
 		}
 
@@ -96,14 +126,46 @@ func RunCLI(
 			}
 
 			if actionIsEmptyDeleteFolders {
-				for i := len(toDeleteEmptyFolders) - 1; i >= 0; i-- {
-					os.Remove(toDeleteEmptyFolders[i])
+				actionName := "delete empty folder"
+				if config.DryRun {
+					actionName = "planned delete empty folder"
 				}
-				fmt.Println()
-				printer.PrintSuccess("Number of deleted empty folders: %d", len(toDeleteEmptyFolders))
+
+				for i := len(toDeleteEmptyFolders) - 1; i >= 0; i-- {
+					path := toDeleteEmptyFolders[i]
+					if config.ReportPath != "" {
+						info, err := os.Stat(path)
+						if err == nil {
+							reportEntries = append(reportEntries, utils.ReportEntry{
+								Path:      path,
+								Action:    actionName,
+								Size:      0,
+								Timestamp: info.ModTime(),
+							})
+						}
+					}
+
+					if !config.DryRun {
+						os.Remove(path)
+					}
+				}
+
+				if !config.DryRun {
+					fmt.Println()
+					printer.PrintSuccess("Number of deleted empty folders: %d", len(toDeleteEmptyFolders))
+				} else {
+					printer.PrintInfo("Dry run: empty folders were not deleted.")
+				}
 			}
 		} else {
 			printer.PrintWarning("Empty folders not found")
+		}
+	}
+	if config.ReportPath != "" {
+		if err := utils.GenerateReport(reportEntries, config.ReportPath, config.ReportFormat); err != nil {
+			printer.PrintError("Failed to generate report: %v", err)
+		} else {
+			printer.PrintSuccess("Report exported to: %s", config.ReportPath)
 		}
 	}
 }

--- a/internal/utils/report.go
+++ b/internal/utils/report.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ReportEntry represents an entry in the exported report
+type ReportEntry struct {
+	Path      string    `json:"path"`
+	Action    string    `json:"action"`
+	Size      int64     `json:"size"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// GenerateReport exports the collected file actions to a JSON or CSV file
+func GenerateReport(entries []ReportEntry, path string, format string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create report file: %v", err)
+	}
+	defer file.Close()
+
+	if format == "csv" {
+		writer := csv.NewWriter(file)
+		defer writer.Flush()
+
+		// Write header
+		if err := writer.Write([]string{"Path", "Action", "Size (bytes)", "Timestamp"}); err != nil {
+			return fmt.Errorf("failed to write CSV header: %v", err)
+		}
+
+		// Write entries
+		for _, entry := range entries {
+			if err := writer.Write([]string{
+				entry.Path,
+				entry.Action,
+				strconv.FormatInt(entry.Size, 10),
+				entry.Timestamp.Format(time.RFC3339),
+			}); err != nil {
+				return fmt.Errorf("failed to write CSV entry: %v", err)
+			}
+		}
+	} else {
+		// Default to JSON
+		encoder := json.NewEncoder(file)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(entries); err != nil {
+			return fmt.Errorf("failed to encode JSON report: %v", err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR introduces a reporting feature and a dry-run mode to the deletor CLI, enhancing its auditability and providing users with better control over file operations.

Key Changes:
CLI Flags: Added new flags: --report, --report-format, and --dry-run.
Reporting System: Implemented a reporting utility in internal/utils/report.go that supports exporting file actions to both JSON and CSV formats, including file paths, sizes (in bytes), and timestamps.
Dry-Run Mode: Added support for --dry-run, allowing users to see what actions would be taken without actually deleting or moving files.
Action Logging: Updated the CLI runner to collect report data for both files and empty folders, distinguishing between "taken" and "planned" actions.
