### PR TITLE
feat: add --dry-run flag to preview files before deletion

### DIFF
--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	UseRules           bool     // Whether to use rules from configuration file
 	JsonLogsEnabled    bool     // Whether to generates JSON-formatted logs
 	JsonLogsPath       string   // Path to append JSON-formatted logs
+	DryRun             bool     // If true, only preview files without modifying filesystem
 }
 
 // LoadConfig initializes and returns a new Config instance with values from command-line flags

--- a/internal/cli/config/flags.go
+++ b/internal/cli/config/flags.go
@@ -27,6 +27,7 @@ func GetFlags() *Config {
 	moveToTrash := flag.Bool("trash", false, "Move files to trash?")
 	useRules := flag.Bool("rules", false, "Use rules from configuration file")
 	jsonLogsEnabled := flag.Bool("log-json", false, "Enable JSON-formatted logging. Use --log-json or --log-json \"/path/to/file\" to specify a path to write logs.")
+	dryRun := flag.Bool("dry-run", false, "Preview files that would be deleted/trashed without modifying the filesystem")
 
 	flag.Parse()
 
@@ -97,6 +98,7 @@ func GetFlags() *Config {
 	config.DeleteEmptyFolders = *deleteEmptyFolders
 	config.MoveFileToTrash = *moveToTrash
 	config.UseRules = *useRules
+	config.DryRun = *dryRun
 
 	return config
 }

--- a/internal/runner/cli.go
+++ b/internal/runner/cli.go
@@ -49,7 +49,7 @@ func RunCLI(
 		actionIsDelete := true
 
 		fmt.Println() // This is required for formatting
-		if !config.SkipConfirm {
+		if !config.SkipConfirm && !config.DryRun {
 			fmt.Println(utils.FormatSize(totalClearSize), "will be cleared.")
 			var msg string
 			if config.MoveFileToTrash {
@@ -61,22 +61,27 @@ func RunCLI(
 		}
 
 		if actionIsDelete {
-			if config.MoveFileToTrash {
-				for path := range toDeleteMap {
-					fm.MoveFileToTrash(path)
-				}
-				printer.PrintSuccess("Moved to trash: %s", utils.FormatSize(totalClearSize))
+			if config.DryRun {
+				printer.PrintSuccess("[DRY-RUN] Would delete %d file(s) (%s) from %s",
+					len(toDeleteMap), utils.FormatSize(totalClearSize), config.Directory)
 			} else {
-				for path := range toDeleteMap {
-					fm.DeleteFile(path)
+				if config.MoveFileToTrash {
+					for path := range toDeleteMap {
+						fm.MoveFileToTrash(path)
+					}
+					printer.PrintSuccess("Moved to trash: %s", utils.FormatSize(totalClearSize))
+				} else {
+					for path := range toDeleteMap {
+						fm.DeleteFile(path)
+					}
+					printer.PrintSuccess("Deleted: %s", utils.FormatSize(totalClearSize))
 				}
-				printer.PrintSuccess("Deleted: %s", utils.FormatSize(totalClearSize))
-			}
 
-			if config.JsonLogsEnabled {
-				utils.LogDeletionToFileAsJson(toDeleteMap, config.JsonLogsPath)
-			} else {
-				utils.LogDeletionToFile(toDeleteMap)
+				if config.JsonLogsEnabled {
+					utils.LogDeletionToFileAsJson(toDeleteMap, config.JsonLogsPath)
+				} else {
+					utils.LogDeletionToFile(toDeleteMap)
+				}
 			}
 		}
 
@@ -91,16 +96,20 @@ func RunCLI(
 
 			actionIsEmptyDeleteFolders := true
 
-			if !config.SkipConfirm {
+			if !config.SkipConfirm && !config.DryRun {
 				actionIsEmptyDeleteFolders = printer.AskForConfirmation("Delete these empty folders?")
 			}
 
 			if actionIsEmptyDeleteFolders {
-				for i := len(toDeleteEmptyFolders) - 1; i >= 0; i-- {
-					os.Remove(toDeleteEmptyFolders[i])
+				if config.DryRun {
+					printer.PrintSuccess("[DRY-RUN] Would delete %d empty folder(s)", len(toDeleteEmptyFolders))
+				} else {
+					for i := len(toDeleteEmptyFolders) - 1; i >= 0; i-- {
+						os.Remove(toDeleteEmptyFolders[i])
+					}
+					fmt.Println()
+					printer.PrintSuccess("Number of deleted empty folders: %d", len(toDeleteEmptyFolders))
 				}
-				fmt.Println()
-				printer.PrintSuccess("Number of deleted empty folders: %d", len(toDeleteEmptyFolders))
 			}
 		} else {
 			printer.PrintWarning("Empty folders not found")


### PR DESCRIPTION
## Summary

Implements a **Dry-Run / Preview mode** for the CLI as requested in issue #319.

## What changed

Added  flag that:
- Previews files that would be deleted/trashed **without modifying the filesystem**
- Skips the confirmation prompt when  is set
- Shows file count and total size of what would be deleted
- Also handles empty folder deletion preview

## Example usage

```bash
deletor -cli -d ~/Downloads -e mp4,zip --dry-run
# Output: [DRY-RUN] Would delete 12 file(s) (1.2 GB) from /home/user/Downloads

deletor -cli -d ~/Downloads -e mp4,zip --dry-run --trash
# Output: [DRY-RUN] Would delete 12 file(s) (1.2 GB) from /home/user/Downloads
```

## Files changed

-  — added  flag
-  — added  field to Config
-  — added dry-run logic that skips actual deletion

## Use case

Users can safely preview what would be deleted before running for real — helpful for automation scripts, debugging filters, and preventing accidental data loss.

---
Fixes #319